### PR TITLE
fix(package.json): bump version number:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-responsive-iframe",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "main": "src/index.js",
   "repository": "git@github.com:Boaterfly/async-responsive-iframe.git",
   "author": "nfabredev <nicolas.fabre@boaterfly.com>",


### PR DESCRIPTION
In order to do a new release on `npm` we need to update the version number in the package.json.

Git tag are not sufficient 😓.

As `0.1.1` release has already been made, and moving tags is bad, i bump the version to `0.1.2` in order to make a new corresponding tags.

# Learning
It's hard to have the same version number as git tags and npm packages. It should be first done on the `package.json`, then on a release and lastly published to npm